### PR TITLE
Add a little script that automates creating files

### DIFF
--- a/bin/dmca
+++ b/bin/dmca
@@ -15,7 +15,10 @@ ADVANCED:
 
 dmca_title="$@"
 
-[[ -n "$dmca_title" ]] || usage && exit 127
+if [ ! -n "$dmca_title" ]; then
+ usage
+ exit 1
+fi
 
 date_prefix="$(date +%Y-%m-%d)"
 file_title=$(echo "$dmca_title" \
@@ -23,10 +26,10 @@ file_title=$(echo "$dmca_title" \
 	| tr '[:upper:]' '[:lower:]' \
 	| tr -c '[:alnum:]' '-')
 
-filename="${date_prefix}_${file_title}.markdown"
+filename="${date_prefix}-${file_title}.markdown"
 
 if [ -n "$VISUAL" ]; then
-	$VISUAL $filename
+	exec $VISUAL $filename
 else
 	touch $filename
 fi


### PR DESCRIPTION
Cause I don't like to know what date it is our how to title-ize things or remembering which markdown extension we're using.

This script when run as `bin/dmca Some DCMA title` will create the file 2012-09-26-some-dmca-title.markdown. If you have the VISUAL environment variable defined (say as vim, mvim, or subl) it will even open it in your editor for you.
