### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ####What is this?
-Inspired by [Chilling Effects](https://www.chillingeffects.org/topics/1) and [Google](https://developers.google.com/storage/docs/dmca), this repo contains the text of DMCA takedown notices and counter-notices we've received here at GitHub. We publish them as they are received, with only personally identifiable information redacted.
+Inspired by [Chilling Effects](https://lumendatabase.org/topics/1) and [Google](https://cloud.google.com/storage/docs/dmca), this repo contains the text of DMCA takedown notices and counter-notices we've received here at GitHub. We publish them as they are received, with only personally identifiable information redacted.
 
 ####Why is this?
 In short, we believe that transparency is a virtue. Chilling Effects explained it well in 2014 (no longer available online): "We are excited about the new opportunities the Internet offers individuals to express their views . . . but concerned that not everyone feels the same way. Study to date suggests that cease and desist letters often silence Internet users, whether or not their claims have legal merit." (About, ChillingEffects.org, Sept. 2014, licensed under [CC-BY-3.0](http://creativecommons.org/licenses/by/3.0/us/)). Similarly, we post takedown notices here to document their potential to "chill" speech.
@@ -7,7 +7,7 @@ In short, we believe that transparency is a virtue. Chilling Effects explained i
 ####What does it mean if there's a notice posted here?
 It only means that we received the notice on the indicated date. It does ***not*** mean that the takedown was unlawful or wrong. It does ***not*** mean that the user identified in the notice has done anything wrong. We post the notices only for informational purposes. We don't make or imply any judgment about the merit of the claims they make. You can draw your own conclusions.
 
-For more details, see our [DMCA policy](http://help.github.com/dmca-takedown/).
+For more details, see our [DMCA policy](https://help.github.com/dmca-takedown/).
 
 #### Contributing
 We do not accept Pull Requests in this repository. Feel free to comment or make suggestions, but note that we do not actively monitor contributions to this repository. If you would like to contact GitHub about this repository, please contact [GitHub Support](https://github.com/contact/). If you would like to submit a DMCA notice or counter notice, see our [DMCA Policy](https://help.github.com/articles/dmca-takedown-policy/#f-submitting-notices) pages for information on how to do so.


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### Other Corrected URLs 
Was | Now 
--- | --- 
http://help.github.com/dmca-takedown/ | https://help.github.com/dmca-takedown/ 
https://developers.google.com/storage/docs/dmca | https://cloud.google.com/storage/docs/dmca 
https://www.chillingeffects.org/topics/1 | https://lumendatabase.org/topics/1 
