### PR TITLE
Remove gender specific language

### DIFF
--- a/2020/10/2020-10-23-RIAA.md
+++ b/2020/10/2020-10-23-RIAA.md
@@ -2,7 +2,7 @@ October 23, 2020
 
 GitHub
 
-Dear Sir or Madam:
+To Whom It May Concern:
 
 I am contacting you on behalf of the Recording Industry Association of America, Inc. (RIAA) and
 its member record companies. The RIAA is a trade association whose member companies


### PR DESCRIPTION
Original uses "Sir / Madam" which did not include those who do not go by neither Sir nor Madam. This language is much more inclusive & welcoming.